### PR TITLE
Remove duplicate <title> element

### DIFF
--- a/src/app/Document.tsx
+++ b/src/app/Document.tsx
@@ -54,7 +54,6 @@ export const Document: React.FC<{
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>RedwoodSDK is a React framework for Cloudflare</title>
         <link rel="canonical" href={canonicalUrl} />
         <TurnstileScript />
         {/* Icons */}


### PR DESCRIPTION
Each page already has its own `<title>` (besides `404.tsx`, which doesn't appear to be used - `notFound` appears to handle not found pages), so there is no need to have a generic one in `Document`. Also, it isn't technically allowed for a `<head>` to have multiple `<title>`s ([MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/title#technical_summary)).

This is an exciting project and I'm looking forward to exploring it some more!